### PR TITLE
Bump required ruby version to 2.5.0

### DIFF
--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.files         = Dir.glob('lib/**/*')
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.5.0']
 
   s.add_dependency 'sorbet', '~> 0.4.4704'
 


### PR DESCRIPTION
Avoid earlier ruby versions, due to error
```
lib/sorbet-coerce.rb:15: syntax error
```

https://travis-ci.com/chanzuckerberg/sorbet-coerce/jobs/245639472