### PR TITLE
Initial release v0.1.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A type coercion lib works with [Sorbet](https://sorbet.org)'s static type checker and type definitions; raises an error if the coercion fails.
 
+It provides a simple and generic way of coercing types in a sorbet-typed project. It is particularly useful when we're dealing with external API responses and controller parameters.
+
 ## Installation
 1. Follow the steps [here](https://sorbet.org/docs/adopting) to set up the latest version of Sorbet and run `srb tc`.
 2. Add `sorbet-coerce` to your Gemfile and install them with `Bundler`.

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-coerce}
-  s.version       = "0.0.1"
+  s.version       = "0.1.0"
   s.date          = %q{2019-10-04}
-  s.summary       = %q{Type coercion with Sorbet}
+  s.summary       = %q{A type coercion lib works with Sorbet's static type checker and type definitions; raises an error if the coercion fails.}
   s.authors       = ["Chan Zuckerberg Initiative"]
   s.email         = "opensource@chanzuckerberg.com"
   s.homepage      = "https://github.com/chanzuckerberg/sorbet-coerce"


### PR DESCRIPTION
This gem works with Sorbet's static type checker and type definitions. It'll return a statically-typed object or throws `T::CoercionError` if the coercion fails.

It provides a simple and generic way of coercing types in a sorbet-typed project. It is particularly useful when we're dealing with external API responses and controller parameters.

```ruby
converted = T::Coerce[<Type>].new.from(<value>)

T.reveal_type(converted) # <Type>
```

The supported types include
- Simple Types (Integer, String, etc.)
- Custom Types: If the values can be coerced by `.new`
- `T.nilable(<supported type>)`
- `T::Array[<supported type>]`
- Subclasses of `T::Struct`

We don't support
- `T::Hash` (currently)
- `T.any(<supported type>, ...)`: A union type other than `T.nilable`