### PR TITLE
Fix T::Array conversion

### DIFF
--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -27,7 +27,7 @@ module T::Private
       if type.is_a?(T::Types::TypedArray)
         _convert_to_a(value, type.type)
       elsif type.is_a?(T::Types::Simple)
-        _convert_simple(value, type.raw_type)
+        _convert(value, type.raw_type)
       elsif type.is_a?(T::Types::Union)
         raw_types = type.types.map(&:raw_type)
         raise ArgumentError.new(
@@ -74,7 +74,7 @@ module T::Private
 
     sig { params(ary: T.untyped, type: T.untyped).returns(T.untyped) }
     def _convert_to_a(ary, type)
-      ary = [ary] unless ary.respond_to?(:map)
+      ary = [ary] unless ary.is_a?(::Array)
       T.send(
         'let',
         ary.map { |value| _convert(value, type) },

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -139,6 +139,14 @@ describe T::Coerce do
       expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
       ).to eql [[1], [2], [3]]
+
+      infos = T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
+      T.assert_type!(infos, T::Array[ParamInfo])
+      expect(infos.first.name).to eql 'a'
+
+      infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'b', skill_ids: []}])
+      T.assert_type!(infos, T::Array[ParamInfo])
+      expect(infos.first.name).to eql 'b'
     end
   end
 end


### PR DESCRIPTION
**Describe the bug:**
When we're converting `T::Array`, we assumed the raw_type is a simple type. But this is a false assumption. It should recurse to the generic convert method. Also, `Hash` also respond to `.map`, we should check the class instead.

**Steps to reproduce:**
```ruby
T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
# => []
```

**Expected behavior:**
```ruby
T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
# => [<ParamInfo ...>]
```