### PR TITLE
Fix coercing union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ T.reveal_type(converted) # <Type>
 ### Supported Types
 - Simple Types
 - Custom Types: If the values can be coerced by `.new`
+- `T::Boolean`
 - `T.nilable(<supported type>)`
 - `T::Array[<supported type>]`
 - Subclasses of `T::Struct`
@@ -46,6 +47,12 @@ We don't support
 - Simple Types
 
 ```ruby
+T::Coerce[T::Boolean].new.from('false')
+# => false
+
+T::Coerce[T::Boolean].new.from('true')
+# => true
+
 T::Coerce[Date].new.from('2019-08-05')
 # => #<Date: 2019-08-05 ((2458701j,0s,0n),+0s,2299161j)>
 

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -41,13 +41,15 @@ module T::Private
 
         raise ArgumentError.new(
           'the only supported union types are T.nilable and T::Boolean',
-        ) unless type.types.length == 2 && (
-          !nil_idx.nil? || (!true_idx.nil? && !false_idx.nil?)
+        ) unless (
+          (!true_idx.nil? && !false_idx.nil? && !nil_idx.nil?) || # T.nilable(T::Boolean)
+          (type.types.length == 2 && (
+            !nil_idx.nil? || (!true_idx.nil? && !false_idx.nil?) # T.nilable || T::Boolean
+          ))
         )
 
-        if nil_idx.nil?
-          # Must be T::Boolean
-          _convert_simple(value, type)
+        if !true_idx.nil? && !false_idx.nil?
+          _convert_simple(value, T::Boolean)
         else
           _convert(value, type.types[nil_idx == 0 ? 1 : 0])
         end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -130,15 +130,6 @@ describe T::Coerce do
       expect(T::Coerce[T::Array[Integer]].new.from('1')).to eql [1]
       expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
       expect(T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])).to eql []
-      expect(
-        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3']),
-      ).to eql [1, nil, 3]
-      expect(
-        T::Coerce[T::Array[T::Array[Integer]]].new.from(['', '', '']),
-      ).to eql [[], [], []]
-      expect(
-        T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
-      ).to eql [[1], [2], [3]]
 
       infos = T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
       T.assert_type!(infos, T::Array[ParamInfo])

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -23,7 +23,13 @@ describe T::Coerce do
       const :opt, T.nilable(ParamInfo2)
     end
 
-    CustomType = Struct.new(:a)
+    class CustomType
+      attr_reader :a
+
+      def initialize(a)
+        @a = a
+      end
+    end
 
     class UnsupportedCustomType
       # Does not respond to new

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -23,6 +23,12 @@ describe T::Coerce do
       const :opt, T.nilable(ParamInfo2)
     end
 
+    CustomType = Struct.new(:a)
+
+    class UnsupportedCustomType
+      # Does not respond to new
+    end
+
     let!(:param) {
       T::Coerce[Param].new.from({
         id: 1,
@@ -120,6 +126,18 @@ describe T::Coerce do
 
       expect(T::Coerce[T.nilable(Integer)].new.from('invalid integer string')).to be nil
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
+
+      expect(T::Coerce[T::Boolean].new.from('false')).to be false
+      expect(T::Coerce[T::Boolean].new.from('true')).to be true
+    end
+  end
+
+  context 'when given custom types' do
+    it 'coerces correctly' do
+      T.assert_type!(T::Coerce[CustomType].new.from(a: 1), CustomType)
+      expect(T::Coerce[CustomType].new.from(1).a).to be 1
+
+      expect{T::Coerce[UnsupportedCustomType].new.from(1)}.to raise_error(T::CoercionError)
     end
   end
 

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -6,6 +6,7 @@ describe T::Coerce do
   context 'when given nested types' do
     class User < T::Struct
       const :id, Integer
+      const :valid, T.nilable(T::Boolean)
     end
 
     class NestedParam < T::Struct
@@ -17,9 +18,9 @@ describe T::Coerce do
       converted = T::Coerce[NestedParam].new.from({
         users: {id: '1'},
         params: {
-          users: {id: '2'},
+          users: {id: '2', valid: 'true'},
           params: {
-            users: {id: '3'},
+            users: {id: '3', valid: 'true'},
           },
         },
       })
@@ -27,11 +28,11 @@ describe T::Coerce do
       #   params=<NestedParam
       #     params=<NestedParam
       #       params=nil,
-      #       users=[<User id=3>]
+      #       users=[<User id=3 valid=true>]
       #     >,
-      #     users=[<User id=2>]
+      #     users=[<User id=2 valid=true>]
       #   >,
-      #   users=[<User id=1>]
+      #   users=[<User id=1 valid=nil>]
       # >
 
       expect(converted.users.map(&:id)).to eql([1])

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -1,0 +1,78 @@
+# typed: false
+require 'sorbet-coerce'
+require 'sorbet-runtime'
+
+describe T::Coerce do
+  context 'when given nested types' do
+    class User < T::Struct
+      const :id, Integer
+    end
+
+    class NestedParam < T::Struct
+      const :users, T::Array[User]
+      const :params, T.nilable(NestedParam)
+    end
+
+    it 'works with nest T::Struct' do
+      converted = T::Coerce[NestedParam].new.from({
+        users: {id: '1'},
+        params: {
+          users: {id: '2'},
+          params: {
+            users: {id: '3'},
+          },
+        },
+      })
+      # => <NestedParam
+      #   params=<NestedParam
+      #     params=<NestedParam
+      #       params=nil,
+      #       users=[<User id=3>]
+      #     >,
+      #     users=[<User id=2>]
+      #   >,
+      #   users=[<User id=1>]
+      # >
+
+      expect(converted.users.map(&:id)).to eql([1])
+      expect(converted.params.users.map(&:id)).to eql([2])
+      expect(converted.params.params.users.map(&:id)).to eql([3])
+    end
+
+    it 'works with nest T::Array' do
+      expect(
+        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3']),
+      ).to eql [1, nil, 3]
+      expect(
+        T::Coerce[T::Array[T::Array[Integer]]].new.from(['', '', '']),
+      ).to eql [[], [], []]
+      expect(
+        T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
+      ).to eql [[1], [2], [3]]
+
+      expect(T::Coerce[
+        T::Array[
+          T::Array[
+            T::Array[User]
+          ]
+        ]
+      ].new.from([[[{id: '1'}]]]).flatten.first.id).to eql(1)
+
+      expect(T::Coerce[
+        T::Array[
+          T::Array[
+            T::Array[
+              T::Array[
+                T::Array[T.nilable(User)]
+              ]
+            ]
+          ]
+        ]
+      ].new.from(nil).flatten).to eql([nil])
+
+      expect(T::Coerce[
+        T.nilable(T::Array[T.nilable(T::Array[T.nilable(User)])])
+      ].new.from([[{id: '1'}]]).flatten.map(&:id)).to eql([1])
+    end
+  end
+end


### PR DESCRIPTION
- When dealing with union types, we should not assume the other type is a simple type
- We should be more explicit about `T::Boolean`
- Support `T::Boolean`
- When building args for `T::Struct`, we still want to return an empty hash when the value is `nil`
- Add more examples for testing nested types
```ruby
class User < T::Struct
  const :id, Integer
  const :valid, T.nilable(T::Boolean)
end

class NestedParam < T::Struct
  const :users, T::Array[User]
  const :params, T.nilable(NestedParam)
end

converted = T::Coerce[NestedParam].new.from({
  users: {id: '1', valid: 'true'},
  params: {
    users: {id: '2'},
    params: {
      users: {id: '3'},
    },
  },
})

T.reveal_type(converted) # NestedParam

T::Coerce[T::Array[T.nilable(T::Array[T.nilable(User)])]].new.from([[{id: '1'}]])
# => [[<User id=1>]]
```