### PR TITLE
Release v0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class Params < T::Struct
   const :a, Integer
 end
 
-T::Coerce[T::Array[Integer]].new.from('abc')
+T::Coerce[Integer].new.from('abc')
 # => T::CoercionError (Could not coerce value ("abc") of type (String) to desired type (Integer))
 
 T::Coerce[Params].new.from({a: 'abc'})
@@ -130,7 +130,7 @@ T::Coerce[Params].new.from({a: 'abc'})
 
 With soft errors,
 ```ruby
-T::Coerce[T::Array[Integer]].new.from('abc')
+T::Coerce[Integer].new.from('abc')
 # => "abc"
 
 T::Coerce[Params].new.from({a: 'abc'}) # require sorbet version ~> 0.4.4948 or this will still be treated as a hard error

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/b
 
 ## Coercion Error
 
-Sorbet-coerce throws a coercion error when it fails to convert a value into the specified type. The error is [configurable](https://sorbet.org/docs/runtime#changing-the-runtime-behavior) through `T:: Configuration`. In an environment where type errors are configured to be silent (referred to soft errors), when the coercion fails (or constructing T::Struct fails), `T::Coerce` will return the original value instead of actually raising the errors (referred to hard errors).
+Sorbet-coerce throws a coercion error when it fails to convert a value into the specified type. The error is [configurable](https://sorbet.org/docs/runtime#changing-the-runtime-behavior) through `T::Configuration`. In an environment where type errors are configured to be silent (referred to soft errors), when the coercion fails (or constructing `T::Struct` fails), `T::Coerce` will return the original value instead of actually raising the errors (referred to hard errors).
 
 ## `null`, `''`, and `undefined`
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/b
 
 ## Coercion Error
 
+Sorbet-coerce throws a coercion error when it fails to convert a value into the specified type. The error is [configurable](https://sorbet.org/docs/runtime#changing-the-runtime-behavior) through `T:: Configuration`. In an environment where type errors are configured to be silent (referred to soft errors), when the coercion fails (or constructing T::Struct fails), `T::Coerce` will return the original value instead of actually raising the errors (referred to hard errors).
+
+## `null`, `''`, and `undefined`
+
+Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we're coercing object `json` into a `Param` instance
+```ruby
+json = {"a": "1", "null_filed": null, "blank_filed": ""}
+
+class Params < T::Struct
+  const :a, Integer
+  const :null_filed, T.nilable(Integer)
+  const :blank_filed, T.nilable(Integer)
+  const :missing_key, T::Array[Integer], default: []
+end
+
+param = T::Coerce[Params].new.from(json)
+```
+
+- When `json["null_filed"]` is `null`, `param.null_filed` is `nil`
+- When `json["blank_filed"]` is `""`, `param.blank_filed` is `nil`
+- When `json["missing_key"]` is `undefined`, `param.missing_key` will use the default value `[]`
+
 ## Contributing
 
 Contributions and ideas are welcome! Please see [our contributing guide](CONTRIBUTING.md) and don't hesitate to open an issue or send a pull request to improve the functionality of this gem.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ converted = T::Coerce[<Type>].new.from(<value>)
 T.reveal_type(converted) # <Type>
 ```
 
-
-
 ### Supported Types
 - Simple Types
 - Custom Types: If the values can be coerced by `.new`
@@ -41,6 +39,7 @@ T.reveal_type(converted) # <Type>
 
 We don't support
 - `T::Hash` (currently)
+- `T::Enum` (currently)
 - Experimental features (tuples and shapes)
 - `T.any(<supported type>, ...)`: A union type other than `T.nilable`
 
@@ -79,10 +78,7 @@ T::Coerce[Time].new.from('2019-08-05')
 - `T.nilable`
 
 ```ruby
-T::Coerce[Integer].new.from('invalid number')
-# => T::CoercionError (Could not coerce value ("invalid number") of type (String) to desired type (Integer))
-
-T::Coerce[T.nilable(Integer)].new.from('invalid number')
+T::Coerce[T.nilable(Integer)].new.from('')
 # => nil
 ```
 
@@ -91,12 +87,6 @@ T::Coerce[T.nilable(Integer)].new.from('invalid number')
 ```ruby
 T::Coerce[T::Array[Integer]].new.from([1.0, '2.0'])
 # => [1, 2]
-
-T::Coerce[T::Array[Integer]].new.from([1.0, 'invalid num'])
-# => []
-
-T::Coerce[T::Array[T.nilable(Integer)]].new.from([1.0, 'invalid num'])
-# => [1, nil]
 ```
 
 - `T::Struct`
@@ -110,6 +100,9 @@ end
 T::Coerce[Param].new.from({id: '1'})
 # => <Param id=1, role="wizard">
 ```
+More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/blob/a56c0c6a363bb49b11e77ac57893afc3d54c6b8c/spec/nested_spec.rb#L18-L26)
+
+## Coercion Error
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ T::Coerce[Time].new.from('2019-08-05')
 ```ruby
 T::Coerce[T.nilable(Integer)].new.from('')
 # => nil
+T::Coerce[T.nilable(Integer)].new.from(nil)
+# => nil
+T::Coerce[T.nilable(Integer)].new.from('')
+# => nil
+```
+But,
+```
+T::Coerce[T.nilable(String)].new.from('')
+# => ""
 ```
 
 - `T::Array`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Sorbet-coerce throws a coercion error when it fails to convert a value into the 
 
 ## `null`, `''`, and `undefined`
 
-Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we're coercing object `json` into a `Param` instance
+Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we're coercing object `json` into a `Params` instance
 ```ruby
 json = {"a": "1", "null_filed": null, "blank_filed": ""}
 
@@ -119,12 +119,12 @@ class Params < T::Struct
   const :missing_key, T::Array[Integer], default: []
 end
 
-param = T::Coerce[Params].new.from(json)
+params = T::Coerce[Params].new.from(json)
 ```
 
-- When `json["null_filed"]` is `null`, `param.null_filed` is `nil`
-- When `json["blank_filed"]` is `""`, `param.blank_filed` is `nil`
-- When `json["missing_key"]` is `undefined`, `param.missing_key` will use the default value `[]`
+- When `json["null_filed"]` is `null`, `params.null_filed` is `nil`
+- When `json["blank_filed"]` is `""`, `params.blank_filed` is `nil`
+- When `json["missing_key"]` is `undefined`, `params.missing_key` will use the default value `[]`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ T::Coerce[T.nilable(Integer)].new.from(nil)
 T::Coerce[T.nilable(Integer)].new.from('')
 # => nil
 ```
-But,
+But, `''` will be converted to an empty string for `T.nilable(String)` type
 ```ruby
 T::Coerce[T.nilable(String)].new.from('')
 # => ""
@@ -101,13 +101,13 @@ T::Coerce[T::Array[Integer]].new.from([1.0, '2.0'])
 - `T::Struct`
 
 ```ruby
-class Param < T::Struct
+class Params < T::Struct
   const :id, Integer
   const :role, String, default: 'wizard'
 end
 
-T::Coerce[Param].new.from({id: '1'})
-# => <Param id=1, role="wizard">
+T::Coerce[Params].new.from({id: '1'})
+# => <Params id=1, role="wizard">
 ```
 More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/blob/a56c0c6a363bb49b11e77ac57893afc3d54c6b8c/spec/nested_spec.rb#L18-L26)
 
@@ -115,25 +115,57 @@ More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/b
 
 Sorbet-coerce throws a coercion error when it fails to convert a value into the specified type. The error is [configurable](https://sorbet.org/docs/runtime#changing-the-runtime-behavior) through `T::Configuration`. In an environment where type errors are configured to be silent (referred to soft errors), when the coercion fails (or constructing `T::Struct` fails), `T::Coerce` will return the original value instead of actually raising the errors (referred to hard errors).
 
-## `null`, `''`, and `undefined`
-
-Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we're coercing object `json` into a `Params` instance
+With hard errors,
 ```ruby
-json = {"a": "1", "null_filed": null, "blank_filed": ""}
-
 class Params < T::Struct
   const :a, Integer
-  const :null_filed, T.nilable(Integer)
-  const :blank_filed, T.nilable(Integer)
-  const :missing_key, T::Array[Integer], default: []
 end
 
-params = T::Coerce[Params].new.from(json)
+T::Coerce[T::Array[Integer]].new.from('abc')
+# => T::CoercionError (Could not coerce value ("abc") of type (String) to desired type (Integer))
+
+T::Coerce[Params].new.from({a: 'abc'})
+# => T::CoercionError: (Could not coerce value ({:a=>"abc"}) of type (Hash) to desired type (Params))
 ```
 
-- When `json["null_filed"]` is `null`, `params.null_filed` is `nil`
-- When `json["blank_filed"]` is `""`, `params.blank_filed` is `nil`
-- When `json["missing_key"]` is `undefined`, `params.missing_key` will use the default value `[]`
+With soft errors,
+```ruby
+T::Coerce[T::Array[Integer]].new.from('abc')
+# => "abc"
+
+T::Coerce[Params].new.from({a: 'abc'}) # require sorbet version ~> 0.4.4948 or this will still be treated as a hard error
+# => <Params a="abc">
+```
+
+## `null`, `''`, and `undefined`
+
+Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we send a JavaScript object
+```javascript
+json_js = {"a": "1", "null_field": null, "blank_field": ""} // javascript
+```
+to the server side and get a JSON hash
+```ruby
+json_rb = {"a" => "1", "null_field" => nil, "blank_field" => ""} # ruby
+```
+We expect the object to have shape
+```ruby
+class Params < T::Struct
+  const :a, Integer
+  const :null_field, T.nilable(Integer)
+  const :blank_field, T.nilable(Integer)
+  const :missing_key, T::Array[Integer], default: []
+end
+```
+Note: we expect a `Params` instance to have `missing_key`, but the key is missing in the hash.
+
+Then we coerce the object `json_rb` into an instance of `Params`.
+```ruby
+params = T::Coerce[Params].new.from(json_rb)
+# => <Params a=1, blank_field=nil, missing_key=[], null_field=nil>
+```
+- When `json_js["null_field"]` is `null`, `params.null_field` is `nil`
+- When `json_js["blank_field"]` is `""`, `params.blank_field` is `nil`
+- When `json_js["missing_key"]` is `undefined`, `params.missing_key` will use the default value `[]`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ class Params < T::Struct
   const :missing_key, T::Array[Integer], default: []
 end
 ```
-Note: we expect a `Params` instance to have `missing_key`, but the key is missing in the hash.
 
 Then we coerce the object `json_rb` into an instance of `Params`.
 ```ruby

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ T::Coerce[T.nilable(Integer)].new.from('')
 # => nil
 ```
 But,
-```
+```ruby
 T::Coerce[T.nilable(String)].new.from('')
 # => ""
 ```

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ T::Coerce[Params].new.from({a: 'abc'}) # require sorbet version ~> 0.4.4948 or t
 
 Sorbet-coerce is designed in the context of web development. When coercing into a `T::Struct`, the values that need to be coerced are often JSON-like. Suppose we send a JavaScript object
 ```javascript
-json_js = {"a": "1", "null_field": null, "blank_field": ""} // javascript
+json_js = {"a": "1", "null_field": null, "blank_field": "", "missing_key": undefined} // javascript
 ```
 to the server side and get a JSON hash
 ```ruby

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ json_js = {"a": "1", "null_field": null, "blank_field": "", "missing_key": undef
 ```
 to the server side and get a JSON hash
 ```ruby
-json_rb = {"a" => "1", "null_field" => nil, "blank_field" => ""} # ruby
+json_rb = {"a" => "1", "null_field" => nil, "blank_field" => ""} # ruby, note `missing_key` is removed from the hash
 ```
 We expect the object to have shape
 ```ruby

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-coerce}
-  s.version       = "0.1.5"
+  s.version       = "0.1.6"
   s.date          = %q{2019-10-04}
   s.summary       = %q{A type coercion lib works with Sorbet's static type checker and type definitions; raises an error if the coercion fails.}
   s.authors       = ["Chan Zuckerberg Initiative"]


### PR DESCRIPTION
- `T::CoercionError` becomes configurable through `T::Configuration`