### PR TITLE
Update coercion failure handling

### DIFF
--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -58,11 +58,7 @@ module T::Private
         _convert(value, type.aliased_type)
       elsif type < T::Struct
         args = _build_args(value, type.props)
-        begin
-          type.new(args)
-        rescue
-          nil
-        end
+        type.new(args)
       else
         _convert_simple(value, type)
       end
@@ -71,6 +67,7 @@ module T::Private
     sig { params(value: T.untyped, type: T.untyped).returns(T.untyped) }
     def _convert_simple(value, type)
       return nil if value.nil?
+
       safe_type_rule = T.let(nil, T.untyped)
 
       if type == T::Boolean
@@ -84,12 +81,12 @@ module T::Private
       end
       SafeType::coerce(value, safe_type_rule)
     rescue SafeType::EmptyValueError, SafeType::CoercionError
-      nil
+      value
     rescue SafeType::InvalidRuleError
       begin
         type.new(value)
       rescue
-        nil
+        value
       end
     end
 
@@ -101,8 +98,6 @@ module T::Private
         ary.map { |value| _convert(value, type) },
         T.const_get('Array')[type],
       )
-    rescue TypeError
-      []
     end
 
     sig { params(args: T.untyped, props: T.untyped).returns(T.untyped) }

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -66,7 +66,7 @@ module T::Private
 
     sig { params(value: T.untyped, type: T.untyped).returns(T.untyped) }
     def _convert_simple(value, type)
-      return nil if value.nil?
+      return nil if value.nil? || (value == '' && type != String)
 
       safe_type_rule = T.let(nil, T.untyped)
 
@@ -81,12 +81,12 @@ module T::Private
       end
       SafeType::coerce(value, safe_type_rule)
     rescue SafeType::EmptyValueError, SafeType::CoercionError
-      nil
+      value
     rescue SafeType::InvalidRuleError
       begin
         type.new(value)
       rescue
-        nil
+        value
       end
     end
 

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -90,12 +90,8 @@ module T::Private
     def _convert_to_a(ary, type)
       return [] if _nil_like?(ary, type)
 
-      ary = [ary] unless ary.is_a?(::Array)
-      T.send(
-        'let',
-        ary.map { |value| _convert(value, type) },
-        T.const_get('Array')[type],
-      )
+      # Checked by the T.let at root
+      ary.respond_to?(:map) ? ary.map { |value| _convert(value, type) } : ary
     end
 
     sig { params(args: T.untyped, props: T.untyped).returns(T.untyped) }

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -66,7 +66,7 @@ module T::Private
 
     sig { params(value: T.untyped, type: T.untyped).returns(T.untyped) }
     def _convert_simple(value, type)
-      return nil if value.nil? || (value == '' && type != String)
+      return nil if value.nil?
 
       safe_type_rule = T.let(nil, T.untyped)
 
@@ -81,12 +81,12 @@ module T::Private
       end
       SafeType::coerce(value, safe_type_rule)
     rescue SafeType::EmptyValueError, SafeType::CoercionError
-      value
+      nil
     rescue SafeType::InvalidRuleError
       begin
         type.new(value)
       rescue
-        value
+        nil
       end
     end
 

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -66,7 +66,7 @@ module T::Private
 
     sig { params(value: T.untyped, type: T.untyped).returns(T.untyped) }
     def _convert_simple(value, type)
-      return nil if value.nil?
+      return nil if value.nil? || (value == '' && type != String)
 
       safe_type_rule = T.let(nil, T.untyped)
 

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -130,14 +130,14 @@ describe T::Coerce do
       expect(T::Coerce[Integer].new.from(2)).to eql 2
       expect(T::Coerce[Integer].new.from('1.0')).to eql 1
 
-      expect(T::Coerce[T.nilable(Integer)].new.from('invalid integer string')).to be nil
+      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
       expect(T::Coerce[T::Boolean].new.from('true')).to be true
 
       expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
-      expect(T::Coerce[T.nilable(Integer)].new.from([])).to be nil
+      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error
       expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
     end
   end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -108,7 +108,7 @@ describe T::Coerce do
             lvl: 2,
           },
         })
-      }.to raise_error
+      }.to raise_error(ArgumentError)
 
       expect(T::Coerce[DefaultParams].new.from(nil).a).to be 1
       expect(T::Coerce[DefaultParams].new.from('').a).to be 1
@@ -141,14 +141,14 @@ describe T::Coerce do
       expect(T::Coerce[Integer].new.from(2)).to eql 2
       expect(T::Coerce[Integer].new.from('1.0')).to eql 1
 
-      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error
+      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error(T::CoercionError)
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
       expect(T::Coerce[T::Boolean].new.from('true')).to be true
 
       expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
-      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error
+      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error(T::CoercionError)
       expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
     end
   end
@@ -167,10 +167,11 @@ describe T::Coerce do
     it 'coreces correctly' do
       expect(T::Coerce[T::Array[Integer]].new.from(nil)).to eql []
       expect(T::Coerce[T::Array[Integer]].new.from('')).to eql []
-      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error
+      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error(T::CoercionError)
       expect{T::Coerce[T::Array[Integer]].new.from('1')}.to raise_error(T::CoercionError)
       expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
-      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error
+      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error(T::CoercionError)
+      expect{T::Coerce[T::Array[Integer]].new.from({a: 1})}.to raise_error(T::CoercionError)
 
       infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'a', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -130,14 +130,14 @@ describe T::Coerce do
       expect(T::Coerce[Integer].new.from(2)).to eql 2
       expect(T::Coerce[Integer].new.from('1.0')).to eql 1
 
-      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error
+      expect(T::Coerce[T.nilable(Integer)].new.from('invalid integer string')).to be nil
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
       expect(T::Coerce[T::Boolean].new.from('true')).to be true
 
       expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
-      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error
+      expect(T::Coerce[T.nilable(Integer)].new.from([])).to be nil
       expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
     end
   end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -135,6 +135,10 @@ describe T::Coerce do
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
       expect(T::Coerce[T::Boolean].new.from('true')).to be true
+
+      expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
+      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error
+      expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
     end
   end
 

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -13,7 +13,7 @@ describe T::Coerce do
     class ParamInfo2 < T::Struct
       const :a, Integer
       const :b, Integer
-      const :notes, T::Array[String]
+      const :notes, T::Array[String], default: []
     end
 
     class Param < T::Struct
@@ -82,7 +82,7 @@ describe T::Coerce do
       expect(param.info.lvl).to eql 100
       expect(param.info.name).to eql 'mango'
       expect(param.info.skill_ids).to eql [123, 456]
-      expect(param.opt).to be nil # missing notes
+      expect(param.opt.notes).to eql []
 
       expect(param2.id).to eql 2
       expect(param2.info.name).to eql 'honeydew'
@@ -92,15 +92,15 @@ describe T::Coerce do
       expect(param2.opt.b).to eql 2
       expect(param2.opt.notes).to eql []
 
-      expect(
-        T::Coerce[T.nilable(Param)].new.from({
+      expect {
+        T::Coerce[Param].new.from({
           id: 3,
           info: {
             # missing required name
             lvl: 2,
           },
         })
-      ).to be nil
+      }.to raise_error
     end
   end
 
@@ -130,7 +130,7 @@ describe T::Coerce do
       expect(T::Coerce[Integer].new.from(2)).to eql 2
       expect(T::Coerce[Integer].new.from('1.0')).to eql 1
 
-      expect(T::Coerce[T.nilable(Integer)].new.from('invalid integer string')).to be nil
+      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
@@ -149,11 +149,11 @@ describe T::Coerce do
 
   context 'when dealing with arries' do
     it 'coreces correctly' do
-      expect(T::Coerce[T::Array[Integer]].new.from(nil)).to eql []
-      expect(T::Coerce[T::Array[Integer]].new.from('not an array')).to eql []
+      expect{T::Coerce[T::Array[Integer]].new.from(nil)}.to raise_error
+      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error
       expect(T::Coerce[T::Array[Integer]].new.from('1')).to eql [1]
       expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
-      expect(T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])).to eql []
+      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error
 
       infos = T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
       T.assert_type!(infos, T::Array[ParamInfo])

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -168,11 +168,11 @@ describe T::Coerce do
       expect(T::Coerce[T::Array[Integer]].new.from(nil)).to eql []
       expect(T::Coerce[T::Array[Integer]].new.from('')).to eql []
       expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error
-      expect(T::Coerce[T::Array[Integer]].new.from('1')).to eql [1]
+      expect{T::Coerce[T::Array[Integer]].new.from('1')}.to raise_error(T::CoercionError)
       expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
       expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error
 
-      infos = T::Coerce[T::Array[ParamInfo]].new.from(name: 'a', skill_ids: [])
+      infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'a', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])
       expect(infos.first.name).to eql 'a'
 

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -41,12 +41,12 @@ describe T::Coerce do
     end
 
     it 'works with nest T::Array' do
-      expect(
-        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3']),
-      ).to eql [1, nil, 3]
-      expect(
-        T::Coerce[T::Array[T::Array[Integer]]].new.from(['', '', '']),
-      ).to eql [[], [], []]
+      expect {
+        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
+      }.to raise_error
+      expect {
+        T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
+      }.to raise_error
       expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
       ).to eql [[1], [2], [3]]
@@ -64,12 +64,12 @@ describe T::Coerce do
           T::Array[
             T::Array[
               T::Array[
-                T::Array[T.nilable(User)]
+                T::Array[User]
               ]
             ]
           ]
         ]
-      ].new.from(nil).flatten).to eql([nil])
+      ].new.from(id: 1).flatten.first.id).to eql 1
 
       expect(T::Coerce[
         T.nilable(T::Array[T.nilable(T::Array[T.nilable(User)])])

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -41,9 +41,9 @@ describe T::Coerce do
     end
 
     it 'works with nest T::Array' do
-      expect(
-        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3']),
-      ).to eql [1, nil, 3]
+      expect {
+        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
+      }.to raise_error
       expect {
         T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
       }.to raise_error

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -44,9 +44,9 @@ describe T::Coerce do
       expect {
         T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
       }.to raise_error
-      expect {
+      expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
-      }.to raise_error
+      ).to eql([[]])
       expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
       ).to eql [[1], [2], [3]]

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -43,7 +43,7 @@ describe T::Coerce do
     it 'works with nest T::Array' do
       expect {
         T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
-      }.to raise_error
+      }.to raise_error(T::CoercionError)
       expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
       ).to eql([[]])

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -16,11 +16,11 @@ describe T::Coerce do
 
     it 'works with nest T::Struct' do
       converted = T::Coerce[NestedParam].new.from({
-        users: {id: '1'},
+        users: [{id: '1'}],
         params: {
-          users: {id: '2', valid: 'true'},
+          users: [{id: '2', valid: 'true'}],
           params: {
-            users: {id: '3', valid: 'true'},
+            users: [{id: '3', valid: 'true'}],
           },
         },
       })
@@ -69,7 +69,7 @@ describe T::Coerce do
             ]
           ]
         ]
-      ].new.from(id: 1).flatten.first.id).to eql 1
+      ].new.from([[[[[{id: 1}]]]]]).flatten.first.id).to eql 1
 
       expect(T::Coerce[
         T.nilable(T::Array[T.nilable(T::Array[T.nilable(User)])])

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -41,9 +41,9 @@ describe T::Coerce do
     end
 
     it 'works with nest T::Array' do
-      expect {
-        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
-      }.to raise_error
+      expect(
+        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3']),
+      ).to eql [1, nil, 3]
       expect {
         T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
       }.to raise_error

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -20,6 +20,10 @@ describe T::Coerce do
       ).and_return(ignore_error)
     end
 
+    class ParamsWithSortError < T::Struct
+      const :a, Integer
+    end
+
     class CustomTypeRaisesHardError
       def initialize(value)
         raise StandardError.new('value cannot be 1') if value == 1
@@ -41,6 +45,10 @@ describe T::Coerce do
         T::Coerce[CustomTypeRaisesHardError].new.from(1)
       }.to raise_error(StandardError)
       expect(T::Coerce[CustomTypeDoesNotRiaseHardError].new.from(1)).to eql(1)
+
+      if Gem.loaded_specs['sorbet-runtime'].version >= Gem::Version.new('0.4.4948')
+        expect(T::Coerce[ParamsWithSortError].new.from({a: invalid_arg}).a).to eql(invalid_arg)
+      end
     end
   end
 end

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+require 'sorbet-coerce'
+require 'sorbet-runtime'
+
+describe T::Coerce do
+  context 'when type errors are soft errors' do
+    before(:all) do
+      ignore_error = Proc.new {}
+      T::Configuration.inline_type_error_handler = ignore_error
+      T::Configuration.call_validation_error_handler = ignore_error
+      T::Configuration.sig_builder_error_handler = ignore_error
+    end
+
+    class CustomTypeRaisesHardError
+      def initialize(value)
+        raise StandardError.new('value cannot be 1') if value == 1
+      end
+    end
+
+    class CustomTypeDoesNotRiaseHardError
+      def self.new(a); 1; end
+    end
+
+    it 'works as expected' do
+      invalid_arg = 'invalid integer string'
+      expect(T::Coerce[Integer].new.from(invalid_arg)).to eql(invalid_arg)
+      expect {
+        T::Coerce[CustomTypeRaisesHardError].new.from(1)
+      }.to raise_error(StandardError)
+      expect(T::Coerce[CustomTypeDoesNotRiaseHardError].new.from(1)).to eql(1)
+    end
+  end
+end

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -4,11 +4,20 @@ require 'sorbet-runtime'
 
 describe T::Coerce do
   context 'when type errors are soft errors' do
-    before(:all) do
-      ignore_error = Proc.new {}
-      T::Configuration.inline_type_error_handler = ignore_error
-      T::Configuration.call_validation_error_handler = ignore_error
-      T::Configuration.sig_builder_error_handler = ignore_error
+    let(:ignore_error) { Proc.new {} }
+
+    before(:each) do
+      allow(T::Configuration).to receive(
+        :inline_type_error_handler,
+      ).and_return(ignore_error)
+
+      allow(T::Configuration).to receive(
+        :call_validation_error_handler,
+      ).and_return(ignore_error)
+
+      allow(T::Configuration).to receive(
+        :sig_builder_error_handler,
+      ).and_return(ignore_error)
     end
 
     class CustomTypeRaisesHardError
@@ -24,6 +33,9 @@ describe T::Coerce do
     it 'works as expected' do
       invalid_arg = 'invalid integer string'
       expect(T::Coerce[Integer].new.from(invalid_arg)).to eql(invalid_arg)
+      expect(T::Coerce[T::Array[Integer]].new.from(1)).to be 1
+      expect(T::Coerce[T::Array[Integer]].new.from(invalid_arg)).to eql(invalid_arg)
+
       expect {
         T::Coerce[CustomTypeRaisesHardError].new.from(1)
       }.to raise_error(StandardError)

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -35,6 +35,7 @@ describe T::Coerce do
       expect(T::Coerce[Integer].new.from(invalid_arg)).to eql(invalid_arg)
       expect(T::Coerce[T::Array[Integer]].new.from(1)).to be 1
       expect(T::Coerce[T::Array[Integer]].new.from(invalid_arg)).to eql(invalid_arg)
+      expect(T::Coerce[T::Array[Integer]].new.from({a: 1})).to eql([[:a, 1]])
 
       expect {
         T::Coerce[CustomTypeRaisesHardError].new.from(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,3 @@ end
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
-
-RSpec::Expectations.configuration.on_potential_false_positives = :nothing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,5 @@ end
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
+
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing


### PR DESCRIPTION
This PR changes the behavior when a coercion failure occurs. Previously a failure will result in a nil value and will result in a hard error (It did not respect sorbet configuration).

So instead, we should return the original value when coercion fails. The environment is configured to trigger a hard error, it works as before (raised TypeError from `T.let`). If the environment is configured for soft errors only, now we will use the original value instead of failing it by force.