### PR TITLE
Update dependent sorbet version

### DIFF
--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 2.3.0', '< 2.7.0']
 
-  s.add_dependency 'sorbet', '~> 0.4.4704'
+  s.add_dependency 'sorbet', '>= 0.4.4704'
 
   s.add_runtime_dependency 'polyfill', '~> 1.8'
   s.add_runtime_dependency 'safe_type', '~> 1.1', '>= 1.1.1'
-  s.add_runtime_dependency 'sorbet-runtime', '~> 0.4.4704'
+  s.add_runtime_dependency 'sorbet-runtime', '>= 0.4.4704'
 
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8'
   s.add_development_dependency 'byebug', '~>11.0.1', '>=11.0.1'


### PR DESCRIPTION
Current specification means it doesn't allow 0.5.x sorbet versions. Change `~>` to `>=` in the gemspec file.