### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 before_install:
 - gem install bundler -v 2.0.1 --no-doc
 - gem install bundler -v 1.17.3 --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
 - 2.6
 - 2.7
 - ruby-head
-
+allow_failures:
+  - rvm: ruby-head
 before_install:
 - gem install bundler -v 2.0.1 --no-doc
 - gem install bundler -v 1.17.3 --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
 - 2.6
 - 2.7
 - ruby-head
-allow_failures:
+matrix:
+  allow_failures:
   - rvm: ruby-head
 before_install:
 - gem install bundler -v 2.0.1 --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ env:
     secure: c/H6fs0danhoA80/n4lr6YLcYE8rGSW3hVhnFg7CNOKkUIUrqnUtTESvqn8gK6yo97RKw237aEQFIiG+SJx/eZLbfOomSrB5zcY1Lk0dovKYvfk7eFtnWpNAnpuSmZmyQkN06eXAhqgVuZhiHIEqy4AI8zVz/tXvbXPUK9SP/Vxr9pS4f2BqDIGGgkr0Agbeepf8b5fA/XmypQ7wEKcuMT40PH3sfGom4iK/QXW610YjyioFGcQXryrooD/OX58YGSzQA7qmVOIJj9hiF9iKC5mC71WWBLM7W+B6KpRPnmaa0Kmmgspy0w4J2RZw/SyRMByFjWXdM9OznvGlsGGWXN8u+pEFVUCKAcxUPD0kA5Nh8kLP8yxoVT9QMOgdU9K3oxNT45Lg9sITdT/54FU2/Su30MZWOI1JbqWDL3iCOaI/2ozMXhaklm6MAEbbcaSSoTbuWlsPbg1JTjYH8VA0Np5r2BJ2nLttIlFZanaPRa3HQ8F00auHfdxhe6T+6mEjb4etfOyGMjXQn/FZ4DfwcK6KESfyu6/6UrEgy87Oz3Nads/a+42S8NYJkHl4FC6tMzbVY+aGlRUsk0DF1MjHOSBVW7solh+TcJShIfSZTVmizZ8WVCpPHyxBRoqIqk3a3jUQatgYhaKYiwzI22m4qSrHAWtWXAs7TZ8BU4pxjNA=
 language: ruby
 rvm:
-- 2.3
 - 2.4
 - 2.5
 - 2.6
 - 2.7
+- ruby-head
+
 before_install:
 - gem install bundler -v 2.0.1 --no-doc
 - gem install bundler -v 1.17.3 --no-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
-- ruby-head
 before_install:
 - gem install bundler -v 2.0.1 --no-doc
 - gem install bundler -v 1.17.3 --no-doc

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -3,10 +3,7 @@ require 'safe_type'
 require 'sorbet-runtime'
 require 'polyfill'
 
-using Polyfill(
-  Hash: %w[#slice],
-  Symbol: %w[#match?],
-)
+using Polyfill(Hash: %w[#slice])
 
 module T; end
 

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -3,7 +3,10 @@ require 'safe_type'
 require 'sorbet-runtime'
 require 'polyfill'
 
-using Polyfill(Hash: %w[#slice])
+using Polyfill(
+  Hash: %w[#slice],
+  Symbol: %w[#match?],
+)
 
 module T; end
 

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         += Dir.glob('spec/**/*')
   s.files         += Dir.glob('rbi/**/*')
 
-  s.required_ruby_version = ['>= 2.3.0', '< 2.7.0']
+  s.required_ruby_version = ['>= 2.3.0', '< 2.8.0']
 
   s.add_dependency 'sorbet', '>= 0.4.4704'
 

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         += Dir.glob('spec/**/*')
   s.files         += Dir.glob('rbi/**/*')
 
-  s.required_ruby_version = ['>= 2.3.0', '< 2.8.0']
+  s.required_ruby_version = ['>= 2.4.0', '< 2.8.0']
 
   s.add_dependency 'sorbet', '>= 0.4.4704'
 

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         += Dir.glob('spec/**/*')
   s.files         += Dir.glob('rbi/**/*')
 
-  s.required_ruby_version = ['>= 2.4.0', '< 2.8.0']
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'sorbet', '>= 0.4.4704'
 

--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         += Dir.glob('spec/**/*')
   s.files         += Dir.glob('rbi/**/*')
 
-  s.required_ruby_version = ['>= 2.3.0']
+  s.required_ruby_version = ['>= 2.3.0', '< 2.7.0']
 
   s.add_dependency 'sorbet', '>= 0.4.4704'
 

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -46,7 +46,8 @@ describe T::Coerce do
       }.to raise_error(StandardError)
       expect(T::Coerce[CustomTypeDoesNotRiaseHardError].new.from(1)).to eql(1)
 
-      if Gem.loaded_specs['sorbet-runtime'].version >= Gem::Version.new('0.4.4948')
+      sorbet_version = Gem.loaded_specs['sorbet-runtime'].version
+      if sorbet_version >= Gem::Version.new('0.4.4948') && sorbet_version < Gem::Version.new('0.5.0')
         expect(T::Coerce[ParamsWithSortError].new.from({a: invalid_arg}).a).to eql(invalid_arg)
       end
     end


### PR DESCRIPTION
- Skip ruby version 2.3
- Skip a soft error spec for newer sorbet versions
- Allow the current ruby-head (ruby 2.8.0dev) to fail