### PR TITLE
Add sorbet configuration

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,15 @@
+# typed: true
+require 'sorbet-runtime'
+
+module T::Coerce
+  module Configuration
+    class << self
+      extend T::Sig
+
+      sig { returns(T::Boolean) }
+      attr_accessor :raise_coercion_error
+    end
+  end
+end
+
+T::Coerce::Configuration.raise_coercion_error = true

--- a/lib/sorbet-coerce.rb
+++ b/lib/sorbet-coerce.rb
@@ -1,22 +1,22 @@
 # typed: strict
+require_relative 'configuration'
 require 'private/converter'
 require 'safe_type'
 
-module T
+module T::Coerce
   class CoercionError < SafeType::CoercionError; end
+  class ShapeError < SafeType::CoercionError; end
 
-  module Coerce
-    define_singleton_method(:[]) do |type|
-      Class.new(T::Private::Converter) do
-        define_method(:to_s) { "#{name}#[#{type.to_s}]" }
+  define_singleton_method(:[]) do |type|
+    Class.new(T::Private::Converter) do
+      define_method(:to_s) { "#{name}#[#{type.to_s}]" }
 
-        define_method(:from) do |args|
-          begin
-            T.send('let', send('_convert', args, type), type)
-          rescue TypeError
-            raise CoercionError.new(args, type)
-          end
+      define_method(:from) do |args, raise_coercion_error: nil|
+        if raise_coercion_error.nil?
+          raise_coercion_error = T::Coerce::Configuration.raise_coercion_error
         end
+
+        T.send('let', send('_convert', args, type, raise_coercion_error), type)
       end
     end
   end

--- a/rbi/sorbet-coerce.rbi
+++ b/rbi/sorbet-coerce.rbi
@@ -6,8 +6,8 @@ module T
 
     Elem = type_member
 
-    sig { params(args: T.untyped).returns(Elem) }
-    def from(args); end
+    sig { params(args: T.untyped, raise_value_error: T.nilable(T::Boolean)).returns(Elem) }
+    def from(args, raise_value_error: nil); end
   end
 
   module Private

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -136,19 +136,19 @@ describe T::Coerce do
     end
 
     it 'coreces correctly' do
-      expect{T::Coerce[Integer].new.from(nil)}.to raise_error(T::CoercionError)
+      expect{T::Coerce[Integer].new.from(nil)}.to raise_error(TypeError)
       expect(T::Coerce[T.nilable(Integer)].new.from(nil) || 1).to eql 1
       expect(T::Coerce[Integer].new.from(2)).to eql 2
       expect(T::Coerce[Integer].new.from('1.0')).to eql 1
 
-      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error(T::CoercionError)
+      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error(T::Coerce::CoercionError)
       expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
 
       expect(T::Coerce[T::Boolean].new.from('false')).to be false
       expect(T::Coerce[T::Boolean].new.from('true')).to be true
 
       expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
-      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error(T::CoercionError)
+      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error(T::Coerce::CoercionError)
       expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
     end
   end
@@ -159,7 +159,8 @@ describe T::Coerce do
       expect(T::Coerce[CustomType].new.from(1).a).to be 1
 
       expect{T::Coerce[UnsupportedCustomType].new.from(1)}.to raise_error(ArgumentError)
-      expect{T::Coerce[CustomType2].new.from(1)}.to raise_error(T::CoercionError)
+      # CustomType2.new(anything) returns Integer 1; 1.is_a?(CustomType2) == false
+      expect{T::Coerce[CustomType2].new.from(1)}.to raise_error(TypeError)
     end
   end
 
@@ -167,11 +168,11 @@ describe T::Coerce do
     it 'coreces correctly' do
       expect(T::Coerce[T::Array[Integer]].new.from(nil)).to eql []
       expect(T::Coerce[T::Array[Integer]].new.from('')).to eql []
-      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error(T::CoercionError)
-      expect{T::Coerce[T::Array[Integer]].new.from('1')}.to raise_error(T::CoercionError)
+      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error(T::Coerce::ShapeError)
+      expect{T::Coerce[T::Array[Integer]].new.from('1')}.to raise_error(T::Coerce::ShapeError)
       expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
-      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error(T::CoercionError)
-      expect{T::Coerce[T::Array[Integer]].new.from({a: 1})}.to raise_error(T::CoercionError)
+      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error(T::Coerce::CoercionError)
+      expect{T::Coerce[T::Array[Integer]].new.from({a: 1})}.to raise_error(T::Coerce::CoercionError)
 
       infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'a', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])
@@ -180,6 +181,10 @@ describe T::Coerce do
       infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'b', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])
       expect(infos.first.name).to eql 'b'
+
+      expect {
+        T::Coerce[ParamInfo2].new.from({a: nil, b: nil})
+      }.to raise_error(TypeError)
     end
   end
 

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -43,7 +43,7 @@ describe T::Coerce do
     it 'works with nest T::Array' do
       expect {
         T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
-      }.to raise_error(T::CoercionError)
+      }.to raise_error(T::Coerce::CoercionError)
       expect(
         T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
       ).to eql([[]])


### PR DESCRIPTION
This splits the `CoercionError` into `CoercionError`, `ShapeError`, and `TypeError`s. Coercion errors now become configurable through `T::Coerce::Configuration`. When the value errors are disabled, when it fails to convert, a `nil` value will be used to fill. Coercion errors can also be configured per call-site.