### PR TITLE
Release v0.2.0

### DIFF
--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-coerce}
-  s.version       = "0.1.6"
+  s.version       = "0.2.0"
   s.date          = %q{2019-10-04}
   s.summary       = %q{A type coercion lib works with Sorbet's static type checker and type definitions; raises an error if the coercion fails.}
   s.authors       = ["Chan Zuckerberg Initiative"]


### PR DESCRIPTION
This release adds `T::Coerce::Configuration` for configuring `CoercionError`. We have `CoercionError`, `ShapeError`, or `TypeError` when the coercion doesn't work successfully.

#### `T::Coerce::CoercionError` (configurable)
It raises a coercion error when it fails to convert a value into the specified type (i.e. `'bad string args' to Integer`). This can be configured globally or at each call-site. When configured to `true`, it will fill the result with `nil` instead of raising the errors.
```ruby
T::Coerce::Configuration.raise_coercion_error = false # default to true
```
We can use an inline flag to overwrite the global configuration:
```ruby
T::Coerce[T.nilable(Integer)].new.from('abc', raise_coercion_error: false)
# => nil
```

#### `T::Coerce::ShapeError` (NOT configurable)
It raises a shape error when the shape of the input does not match the shape of input type (i.e. `'1' to T::Array[Integer]` or to `T::Struct`). This cannot be configured and always raise an error.

#### `TypeError` (configurable)
It raises a type error when the coerced input does not match the input type. This error is raised by Sorbet and can be configured through [`T::Configuration`](https://sorbet.org/docs/tconfiguration).