### PR TITLE
Fix sig in the rbi file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 script:
 - mv rbi/* lib/ && srb tc && mv lib/*.rbi rbi/
 - bundle exec rspec
+- bundle exec ruby spec/sorbet_test_cases.rb
 deploy:
   provider: rubygems
   gem: sorbet-coerce

--- a/rbi/sorbet-coerce.rbi
+++ b/rbi/sorbet-coerce.rbi
@@ -6,8 +6,8 @@ module T
 
     Elem = type_member
 
-    sig { params(args: T.untyped, raise_value_error: T.nilable(T::Boolean)).returns(Elem) }
-    def from(args, raise_value_error: nil); end
+    sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
+    def from(args, raise_coercion_error: nil); end
   end
 
   module Private

--- a/spec/sorbet_test_cases.rb
+++ b/spec/sorbet_test_cases.rb
@@ -1,0 +1,22 @@
+# typed: true
+require 'sorbet-coerce'
+
+T.assert_type!(T::Coerce[Integer].new.from('1'), Integer)
+T.assert_type!(
+  T::Coerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
+  T.nilable(Integer),
+)
+
+T::Coerce::Configuration.raise_coercion_error = true
+coercion_error = nil
+begin
+  T::Coerce[T.nilable(Integer)].new.from('invalid')
+rescue T::Coerce::CoercionError => e
+  coercion_error = e
+end
+raise 'no coercion error is raised' unless coercion_error
+
+T.assert_type!(
+  T::Coerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
+  T.nilable(Integer),
+)


### PR DESCRIPTION
This fixes an outdated signature in `rbi/sorbet-coerce.rbi` and adds static type checking cases for catching this type of error in the future.