### PR TITLE
Support T::Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ T.reveal_type(converted) # <Type>
 - `T::Boolean`
 - `T.nilable(<supported type>)`
 - `T::Array[<supported type>]`
+- `T::Hash`
 - Subclasses of `T::Struct`
 
 We don't support
-- `T::Hash` (currently)
 - `T::Enum` (currently)
 - Experimental features (tuples and shapes)
 - `T.any(<supported type>, ...)`: A union type other than `T.nilable`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ T.reveal_type(converted) # <Type>
 - `T::Boolean`
 - `T.nilable(<supported type>)`
 - `T::Array[<supported type>]`
-- `T::Hash`
+- `T::Hash[<supported type>, <supported type>]`
 - Subclasses of `T::Struct`
 
 We don't support

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -51,6 +51,17 @@ module T::Private
         else
           _convert(value, type.types[nil_idx == 0 ? 1 : 0], raise_coercion_error)
         end
+      elsif type.is_a?(T::Types::TypedHash)
+        unless value.respond_to?(:map)
+          raise T::Coerce::ShapeError.new(value, type)
+        end
+
+        value.map do |k, v|
+          [
+            _convert(k, type.keys, raise_coercion_error),
+            _convert(v, type.values, raise_coercion_error),
+          ]
+        end.to_h
       elsif Object.const_defined?('T::Private::Types::TypeAlias') &&
             type.is_a?(T::Private::Types::TypeAlias)
         _convert(value, type.aliased_type, raise_coercion_error)

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -188,6 +188,22 @@ describe T::Coerce do
     end
   end
 
+  context 'when dealing with hashes'  do
+    it 'coreces correctly' do
+      expect(T::Coerce[T::Hash[String, T::Boolean]].new.from({
+        a: 'true',
+        b: 'false',
+      })).to eql({
+        'a' => true,
+        'b' => false,
+      })
+
+      expect {
+        T::Coerce[T::Hash[String, Integer]].new.from(1)
+      }.to raise_error(T::Coerce::ShapeError)
+    end
+  end
+
   context 'when given a type alias' do
     MyType = T.type_alias(T::Boolean)
 

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -27,6 +27,10 @@ describe T::Coerce do
       const :a, Integer, default: 1
     end
 
+    class HashParams < T::Struct
+      const :myhash, T::Hash[String, Integer]
+    end
+
     class CustomType
       attr_reader :a
 
@@ -197,6 +201,18 @@ describe T::Coerce do
         'a' => true,
         'b' => false,
       })
+
+      expect(T::Coerce[HashParams].new.from({
+        myhash: {'a' => '1', 'b' => '2'},
+      }).myhash).to eql({'a' => 1, 'b' => 2})
+
+
+      expect {
+        T::Coerce[T::Hash[String, T::Boolean]].new.from({
+          a: 'invalid',
+          b: 'false',
+        })
+      }.to raise_error(T::Coerce::CoercionError)
 
       expect {
         T::Coerce[T::Hash[String, Integer]].new.from(1)


### PR DESCRIPTION
This adds support for `T::Hash`. For example
```
T::Coerce[T::Hash[String, T::Boolean]].new.from({
  a: 'true',
  b: 'false',
})
# => {'a' => true, 'b' => false}

class MyParams < T::Struct
  const :hash, T::Hash[String, T::Boolean]
end
T::Coerce[MyParams].new.from(...)
```
