### PR TITLE
Add error classes in the bundled rbi file

### DIFF
--- a/rbi/sorbet-coerce.rbi
+++ b/rbi/sorbet-coerce.rbi
@@ -1,4 +1,8 @@
 # typed: true
+module SafeType
+  class CoercionError < StandardError; end
+end
+
 module T
   module Coerce
     extend T::Sig
@@ -9,8 +13,8 @@ module T
     sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
     def from(args, raise_coercion_error: nil); end
 
-    class CoercionError < StandardError; end
-    class ShapeError < StandardError; end
+    class CoercionError < SafeType::CoercionError; end
+    class ShapeError < SafeType::CoercionError; end
   end
 
   module Private

--- a/rbi/sorbet-coerce.rbi
+++ b/rbi/sorbet-coerce.rbi
@@ -8,6 +8,9 @@ module T
 
     sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
     def from(args, raise_coercion_error: nil); end
+
+    class CoercionError < StandardError; end
+    class ShapeError < StandardError; end
   end
 
   module Private


### PR DESCRIPTION
This allows sorbet to pick up the sorbet-coerce error classes so it does not have to generate those. 