### PR TITLE
Release v0.2.2

### DIFF
--- a/sorbet-coerce.gemspec
+++ b/sorbet-coerce.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = %q{sorbet-coerce}
-  s.version       = "0.2.1"
+  s.version       = "0.2.2"
   s.date          = %q{2019-10-04}
   s.summary       = %q{A type coercion lib works with Sorbet's static type checker and type definitions; raises an error if the coercion fails.}
   s.authors       = ["Chan Zuckerberg Initiative"]


### PR DESCRIPTION
- Support `T::Hash`
- Bundle signatures for sorbet-coerce error classes