### PR TITLE
Rename T::Coerce to TypeCoerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ gem 'sorbet-coerce'
 
 ## Usage
 
-`T::Coerce` takes a valid sorbet type and coerce the input value into that type. It'll return a statically-typed object or throws errors when the coercion process cannot be handled as expected (more details in the [Errors](#errors) section).
+`TypeCoerce` takes a valid sorbet type and coerce the input value into that type. It'll return a statically-typed object or throws errors when the coercion process cannot be handled as expected (more details in the [Errors](#errors) section).
 ```ruby
-converted = T::Coerce[<Type>].new.from(<value>)
+converted = TypeCoerce[<Type>].new.from(<value>)
 
 T.reveal_type(converted) # <Type>
 ```
@@ -49,54 +49,54 @@ We don't support
 - Simple Types
 
 ```ruby
-T::Coerce[T::Boolean].new.from('false')
+TypeCoerce[T::Boolean].new.from('false')
 # => false
 
-T::Coerce[T::Boolean].new.from('true')
+TypeCoerce[T::Boolean].new.from('true')
 # => true
 
-T::Coerce[Date].new.from('2019-08-05')
+TypeCoerce[Date].new.from('2019-08-05')
 # => #<Date: 2019-08-05 ((2458701j,0s,0n),+0s,2299161j)>
 
-T::Coerce[DateTime].new.from('2019-08-05')
+TypeCoerce[DateTime].new.from('2019-08-05')
 # => #<DateTime: 2019-08-05T00:00:00+00:00 ((2458701j,0s,0n),+0s,2299161j)>
 
-T::Coerce[Float].new.from('1')
+TypeCoerce[Float].new.from('1')
 # => 1.0
 
-T::Coerce[Integer].new.from('1')
+TypeCoerce[Integer].new.from('1')
 # => 1
 
-T::Coerce[String].new.from(1)
+TypeCoerce[String].new.from(1)
 # => "1"
 
-T::Coerce[Symbol].new.from('a')
+TypeCoerce[Symbol].new.from('a')
 # => :a
 
-T::Coerce[Time].new.from('2019-08-05')
+TypeCoerce[Time].new.from('2019-08-05')
 # => 2019-08-05 00:00:00 -0700
 ```
 
 - `T.nilable`
 
 ```ruby
-T::Coerce[T.nilable(Integer)].new.from('')
+TypeCoerce[T.nilable(Integer)].new.from('')
 # => nil
-T::Coerce[T.nilable(Integer)].new.from(nil)
+TypeCoerce[T.nilable(Integer)].new.from(nil)
 # => nil
-T::Coerce[T.nilable(Integer)].new.from('')
+TypeCoerce[T.nilable(Integer)].new.from('')
 # => nil
 ```
 But, `''` will be converted to an empty string for `T.nilable(String)` type
 ```ruby
-T::Coerce[T.nilable(String)].new.from('')
+TypeCoerce[T.nilable(String)].new.from('')
 # => ""
 ```
 
 - `T::Array`
 
 ```ruby
-T::Coerce[T::Array[Integer]].new.from([1.0, '2.0'])
+TypeCoerce[T::Array[Integer]].new.from([1.0, '2.0'])
 # => [1, 2]
 ```
 
@@ -108,7 +108,7 @@ class Params < T::Struct
   const :role, String, default: 'wizard'
 end
 
-T::Coerce[Params].new.from({id: '1'})
+TypeCoerce[Params].new.from({id: '1'})
 # => <Params id=1, role="wizard">
 ```
 More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/blob/a56c0c6a363bb49b11e77ac57893afc3d54c6b8c/spec/nested_spec.rb#L18-L26)
@@ -116,18 +116,18 @@ More examples: [nested params](https://github.com/chanzuckerberg/sorbet-coerce/b
 ## Errors
 We will get `CoercionError`, `ShapeError`, or `TypeError` when the coercion doesn't work successfully.
 
-#### `T::Coerce::CoercionError` (configurable)
+#### `TypeCoerce::CoercionError` (configurable)
 It raises a coercion error when it fails to convert a value into the specified type (i.e. `'bad string args' to Integer`). This can be configured globally or at each call-site. When configured to `true`, it will fill the result with `nil` instead of raising the errors.
 ```ruby
-T::Coerce::Configuration.raise_coercion_error = false # default to true
+TypeCoerce::Configuration.raise_coercion_error = false # default to true
 ```
 We can use an inline flag to overwrite the global configuration:
 ```ruby
-T::Coerce[T.nilable(Integer)].new.from('abc', raise_coercion_error: false)
+TypeCoerce[T.nilable(Integer)].new.from('abc', raise_coercion_error: false)
 # => nil
 ```
 
-#### `T::Coerce::ShapeError` (NOT configurable)
+#### `TypeCoerce::ShapeError` (NOT configurable)
 It raises a shape error when the shape of the input does not match the shape of input type (i.e. `'1' to T::Array[Integer]` or to `T::Struct`). This cannot be configured and always raise an error.
 
 #### `TypeError` (configurable)
@@ -135,7 +135,7 @@ It raises a type error when the coerced input does not match the input type. Thi
 
 
 #### Soft Errors vs. Hard Errors
-In an environment where type errors and coercion errors are configured to be silent (referred to as soft errors), when the coercion fails, `T::Coerce` will fill the result with `nil` instead of actually raising the errors (referred to hard errors).
+In an environment where type errors and coercion errors are configured to be silent (referred to as soft errors), when the coercion fails, `TypeCoerce` will fill the result with `nil` instead of actually raising the errors (referred to hard errors).
 
 With hard errors,
 ```ruby
@@ -143,29 +143,29 @@ class Params < T::Struct
   const :a, Integer
 end
 
-T::Coerce[Integer].new.from(nil)
+TypeCoerce[Integer].new.from(nil)
 # => TypeError Exception: T.let: Expected type Integer, got type NilClass
 
-T::Coerce[Integer].new.from('abc')
-# => T::Coerce::CoercionError Exception: Could not coerce value ("abc") of type (String) to desired type (Integer)
+TypeCoerce[Integer].new.from('abc')
+# => TypeCoerce::CoercionError Exception: Could not coerce value ("abc") of type (String) to desired type (Integer)
 
-T::Coerce[T.nilable(Integer)].new.from('abc', raise_coercion_error: false)
+TypeCoerce[T.nilable(Integer)].new.from('abc', raise_coercion_error: false)
 # => nil
 
-T::Coerce[Params].new.from({a: 'abc'}, raise_coercion_error: false)
+TypeCoerce[Params].new.from({a: 'abc'}, raise_coercion_error: false)
 # => TypeError Exception: Parameter 'a': Can't set Params.a to nil (instance of NilClass) - need a Integer
 ```
 
 With soft errors,
 ```ruby
-T::Coerce[Integer].new.from('abc', raise_coercion_error: false)
+TypeCoerce[Integer].new.from('abc', raise_coercion_error: false)
 # => nil
 
-T::Coerce[Params].new.from({a: 'abc'}, raise_coercion_error: false) # require sorbet version ~> 0.4.4948
+TypeCoerce[Params].new.from({a: 'abc'}, raise_coercion_error: false) # require sorbet version ~> 0.4.4948
 # => <Params a=nil>
 
-T::Coerce[Params].new.from({a: 'abc'}, raise_coercion_error: true)
-# T::Coerce::CoercionError Exception: Could not coerce value ("abc") of type (String) to desired type (Integer)
+TypeCoerce[Params].new.from({a: 'abc'}, raise_coercion_error: true)
+# TypeCoerce::CoercionError Exception: Could not coerce value ("abc") of type (String) to desired type (Integer)
 ```
 
 ## `null`, `''`, and `undefined`
@@ -190,7 +190,7 @@ end
 
 Then we coerce the object `json_rb` into an instance of `Params`.
 ```ruby
-params = T::Coerce[Params].new.from(json_rb)
+params = TypeCoerce[Params].new.from(json_rb)
 # => <Params a=1, blank_field=nil, missing_key=[], null_field=nil>
 ```
 - When `json_js["null_field"]` is `null`, `params.null_field` is `nil`

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,7 +1,7 @@
 # typed: true
 require 'sorbet-runtime'
 
-module T::Coerce
+module TypeCoerce
   module Configuration
     class << self
       extend T::Sig
@@ -12,4 +12,4 @@ module T::Coerce
   end
 end
 
-T::Coerce::Configuration.raise_coercion_error = true
+TypeCoerce::Configuration.raise_coercion_error = true

--- a/lib/private/converter.rb
+++ b/lib/private/converter.rb
@@ -6,7 +6,9 @@ require 'polyfill'
 
 using Polyfill(Hash: %w[#slice])
 
-module T::Private
+module TypeCoerce; end
+
+module TypeCoerce::Private
   class Converter
     extend T::Sig
 
@@ -58,7 +60,7 @@ module T::Private
         end
       elsif type.is_a?(T::Types::TypedHash)
         unless value.respond_to?(:map)
-          raise T::Coerce::ShapeError.new(value, type)
+          raise TypeCoerce::ShapeError.new(value, type)
         end
 
         value.map do |k, v|
@@ -96,7 +98,7 @@ module T::Private
       SafeType::coerce(value, safe_type_rule)
     rescue SafeType::EmptyValueError, SafeType::CoercionError
       if raise_coercion_error
-        raise T::Coerce::CoercionError.new(value, type)
+        raise TypeCoerce::CoercionError.new(value, type)
       else
         nil
       end
@@ -109,7 +111,7 @@ module T::Private
       return [] if _nil_like?(ary, type)
 
       unless ary.respond_to?(:map)
-        raise T::Coerce::ShapeError.new(ary, type)
+        raise TypeCoerce::ShapeError.new(ary, type)
       end
 
       ary.map { |value| _convert(value, type, raise_coercion_error) }
@@ -120,7 +122,7 @@ module T::Private
       return {} if _nil_like?(args, Hash)
 
       unless args.respond_to?(:each_pair)
-        raise T::Coerce::ShapeError.new(args, type)
+        raise TypeCoerce::ShapeError.new(args, type)
       end
 
       props = type.props

--- a/lib/sorbet-coerce.rb
+++ b/lib/sorbet-coerce.rb
@@ -3,17 +3,17 @@ require_relative 'configuration'
 require 'private/converter'
 require 'safe_type'
 
-module T::Coerce
+module TypeCoerce
   class CoercionError < SafeType::CoercionError; end
   class ShapeError < SafeType::CoercionError; end
 
   define_singleton_method(:[]) do |type|
-    Class.new(T::Private::Converter) do
+    Class.new(TypeCoerce::Private::Converter) do
       define_method(:to_s) { "#{name}#[#{type.to_s}]" }
 
       define_method(:from) do |args, raise_coercion_error: nil|
         if raise_coercion_error.nil?
-          raise_coercion_error = T::Coerce::Configuration.raise_coercion_error
+          raise_coercion_error = TypeCoerce::Configuration.raise_coercion_error
         end
 
         T.send('let', send('_convert', args, type, raise_coercion_error), type)

--- a/rbi/sorbet-coerce.rbi
+++ b/rbi/sorbet-coerce.rbi
@@ -3,20 +3,20 @@ module SafeType
   class CoercionError < StandardError; end
 end
 
+module TypeCoerce
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
+  def from(args, raise_coercion_error: nil); end
+
+  class CoercionError < SafeType::CoercionError; end
+  class ShapeError < SafeType::CoercionError; end
+end
+
 module T
-  module Coerce
-    extend T::Sig
-    extend T::Generic
-
-    Elem = type_member
-
-    sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
-    def from(args, raise_coercion_error: nil); end
-
-    class CoercionError < SafeType::CoercionError; end
-    class ShapeError < SafeType::CoercionError; end
-  end
-
   module Private
     module Types
       class TypeAlias

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -2,7 +2,7 @@
 require 'sorbet-coerce'
 require 'sorbet-runtime'
 
-describe T::Coerce do
+describe TypeCoerce do
   context 'when given T::Struct' do
     class ParamInfo < T::Struct
       const :name, String
@@ -48,7 +48,7 @@ describe T::Coerce do
     end
 
     let!(:param) {
-      T::Coerce[Param].new.from({
+      TypeCoerce[Param].new.from({
         id: 1,
         info: {
           name: 'mango',
@@ -64,7 +64,7 @@ describe T::Coerce do
     }
 
     let!(:param2) {
-      T::Coerce[Param].new.from({
+      TypeCoerce[Param].new.from({
         id: '2',
         info: {
           name: 'honeydew',
@@ -105,7 +105,7 @@ describe T::Coerce do
       expect(param2.opt.notes).to eql []
 
       expect {
-        T::Coerce[Param].new.from({
+        TypeCoerce[Param].new.from({
           id: 3,
           info: {
             # missing required name
@@ -114,8 +114,8 @@ describe T::Coerce do
         })
       }.to raise_error(ArgumentError)
 
-      expect(T::Coerce[DefaultParams].new.from(nil).a).to be 1
-      expect(T::Coerce[DefaultParams].new.from('').a).to be 1
+      expect(TypeCoerce[DefaultParams].new.from(nil).a).to be 1
+      expect(TypeCoerce[DefaultParams].new.from('').a).to be 1
     end
   end
 
@@ -127,74 +127,74 @@ describe T::Coerce do
 
     it 'raises an error' do
       expect {
-        T::Coerce[Param2].new.from({id: 1, info: 1})
+        TypeCoerce[Param2].new.from({id: 1, info: 1})
       }.to raise_error(ArgumentError)
     end
   end
 
   context 'when given primitive types' do
     it 'reveals the right type' do
-      T.assert_type!(T::Coerce[Integer].new.from(1), Integer)
-      T.assert_type!(T::Coerce[Integer].new.from('1.0'), Integer)
-      T.assert_type!(T::Coerce[T.nilable(Integer)].new.from(nil), T.nilable(Integer))
+      T.assert_type!(TypeCoerce[Integer].new.from(1), Integer)
+      T.assert_type!(TypeCoerce[Integer].new.from('1.0'), Integer)
+      T.assert_type!(TypeCoerce[T.nilable(Integer)].new.from(nil), T.nilable(Integer))
     end
 
     it 'coreces correctly' do
-      expect{T::Coerce[Integer].new.from(nil)}.to raise_error(TypeError)
-      expect(T::Coerce[T.nilable(Integer)].new.from(nil) || 1).to eql 1
-      expect(T::Coerce[Integer].new.from(2)).to eql 2
-      expect(T::Coerce[Integer].new.from('1.0')).to eql 1
+      expect{TypeCoerce[Integer].new.from(nil)}.to raise_error(TypeError)
+      expect(TypeCoerce[T.nilable(Integer)].new.from(nil) || 1).to eql 1
+      expect(TypeCoerce[Integer].new.from(2)).to eql 2
+      expect(TypeCoerce[Integer].new.from('1.0')).to eql 1
 
-      expect{T::Coerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error(T::Coerce::CoercionError)
-      expect(T::Coerce[Float].new.from('1.0')).to eql 1.0
+      expect{TypeCoerce[T.nilable(Integer)].new.from('invalid integer string')}.to raise_error(TypeCoerce::CoercionError)
+      expect(TypeCoerce[Float].new.from('1.0')).to eql 1.0
 
-      expect(T::Coerce[T::Boolean].new.from('false')).to be false
-      expect(T::Coerce[T::Boolean].new.from('true')).to be true
+      expect(TypeCoerce[T::Boolean].new.from('false')).to be false
+      expect(TypeCoerce[T::Boolean].new.from('true')).to be true
 
-      expect(T::Coerce[T.nilable(Integer)].new.from('')).to be nil
-      expect{T::Coerce[T.nilable(Integer)].new.from([])}.to raise_error(T::Coerce::CoercionError)
-      expect(T::Coerce[T.nilable(String)].new.from('')).to eql ''
+      expect(TypeCoerce[T.nilable(Integer)].new.from('')).to be nil
+      expect{TypeCoerce[T.nilable(Integer)].new.from([])}.to raise_error(TypeCoerce::CoercionError)
+      expect(TypeCoerce[T.nilable(String)].new.from('')).to eql ''
     end
   end
 
   context 'when given custom types' do
     it 'coerces correctly' do
-      T.assert_type!(T::Coerce[CustomType].new.from(a: 1), CustomType)
-      expect(T::Coerce[CustomType].new.from(1).a).to be 1
+      T.assert_type!(TypeCoerce[CustomType].new.from(a: 1), CustomType)
+      expect(TypeCoerce[CustomType].new.from(1).a).to be 1
 
-      expect{T::Coerce[UnsupportedCustomType].new.from(1)}.to raise_error(ArgumentError)
+      expect{TypeCoerce[UnsupportedCustomType].new.from(1)}.to raise_error(ArgumentError)
       # CustomType2.new(anything) returns Integer 1; 1.is_a?(CustomType2) == false
-      expect{T::Coerce[CustomType2].new.from(1)}.to raise_error(TypeError)
+      expect{TypeCoerce[CustomType2].new.from(1)}.to raise_error(TypeError)
     end
   end
 
   context 'when dealing with arries' do
     it 'coreces correctly' do
-      expect(T::Coerce[T::Array[Integer]].new.from(nil)).to eql []
-      expect(T::Coerce[T::Array[Integer]].new.from('')).to eql []
-      expect{T::Coerce[T::Array[Integer]].new.from('not an array')}.to raise_error(T::Coerce::ShapeError)
-      expect{T::Coerce[T::Array[Integer]].new.from('1')}.to raise_error(T::Coerce::ShapeError)
-      expect(T::Coerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
-      expect{T::Coerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error(T::Coerce::CoercionError)
-      expect{T::Coerce[T::Array[Integer]].new.from({a: 1})}.to raise_error(T::Coerce::CoercionError)
+      expect(TypeCoerce[T::Array[Integer]].new.from(nil)).to eql []
+      expect(TypeCoerce[T::Array[Integer]].new.from('')).to eql []
+      expect{TypeCoerce[T::Array[Integer]].new.from('not an array')}.to raise_error(TypeCoerce::ShapeError)
+      expect{TypeCoerce[T::Array[Integer]].new.from('1')}.to raise_error(TypeCoerce::ShapeError)
+      expect(TypeCoerce[T::Array[Integer]].new.from(['1', '2', '3'])).to eql [1, 2, 3]
+      expect{TypeCoerce[T::Array[Integer]].new.from(['1', 'invalid', '3'])}.to raise_error(TypeCoerce::CoercionError)
+      expect{TypeCoerce[T::Array[Integer]].new.from({a: 1})}.to raise_error(TypeCoerce::CoercionError)
 
-      infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'a', skill_ids: []}])
+      infos = TypeCoerce[T::Array[ParamInfo]].new.from([{name: 'a', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])
       expect(infos.first.name).to eql 'a'
 
-      infos = T::Coerce[T::Array[ParamInfo]].new.from([{name: 'b', skill_ids: []}])
+      infos = TypeCoerce[T::Array[ParamInfo]].new.from([{name: 'b', skill_ids: []}])
       T.assert_type!(infos, T::Array[ParamInfo])
       expect(infos.first.name).to eql 'b'
 
       expect {
-        T::Coerce[ParamInfo2].new.from({a: nil, b: nil})
+        TypeCoerce[ParamInfo2].new.from({a: nil, b: nil})
       }.to raise_error(TypeError)
     end
   end
 
   context 'when dealing with hashes' do
     it 'coreces correctly' do
-      expect(T::Coerce[T::Hash[String, T::Boolean]].new.from({
+      expect(TypeCoerce[T::Hash[String, T::Boolean]].new.from({
         a: 'true',
         b: 'false',
       })).to eql({
@@ -202,37 +202,37 @@ describe T::Coerce do
         'b' => false,
       })
 
-      expect(T::Coerce[HashParams].new.from({
+      expect(TypeCoerce[HashParams].new.from({
         myhash: {'a' => '1', 'b' => '2'},
       }).myhash).to eql({'a' => 1, 'b' => 2})
 
 
       expect {
-        T::Coerce[T::Hash[String, T::Boolean]].new.from({
+        TypeCoerce[T::Hash[String, T::Boolean]].new.from({
           a: 'invalid',
           b: 'false',
         })
-      }.to raise_error(T::Coerce::CoercionError)
+      }.to raise_error(TypeCoerce::CoercionError)
 
       expect {
-        T::Coerce[T::Hash[String, Integer]].new.from(1)
-      }.to raise_error(T::Coerce::ShapeError)
+        TypeCoerce[T::Hash[String, Integer]].new.from(1)
+      }.to raise_error(TypeCoerce::ShapeError)
     end
   end
 
   context 'when dealing with sets' do
     it 'coreces correctly' do
-      expect(T::Coerce[T::Set[Integer]].new.from(
+      expect(TypeCoerce[T::Set[Integer]].new.from(
         Set.new(['1', '2', '3'])
       )).to eq Set.new([1, 2, 3])
 
       expect {
-        T::Coerce[T::Set[Integer]].new.from(Set.new(['1', 'invalid', '3']))
-      }.to raise_error(T::Coerce::CoercionError)
+        TypeCoerce[T::Set[Integer]].new.from(Set.new(['1', 'invalid', '3']))
+      }.to raise_error(TypeCoerce::CoercionError)
 
       expect {
-        T::Coerce[T::Set[Integer]].new.from(1)
-      }.to raise_error(T::Coerce::ShapeError)
+        TypeCoerce[T::Set[Integer]].new.from(1)
+      }.to raise_error(TypeCoerce::ShapeError)
     end
   end
 
@@ -240,14 +240,14 @@ describe T::Coerce do
     MyType = T.type_alias(T::Boolean)
 
     it 'coerces correctly' do
-      expect(T::Coerce[MyType].new.from('false')).to be false
+      expect(TypeCoerce[MyType].new.from('false')).to be false
     end
   end
 
   it 'works with T.untyped' do
-    expect(T::Coerce[T.untyped].new.from(1)).to eql 1
+    expect(TypeCoerce[T.untyped].new.from(1)).to eql 1
 
     obj = CustomType.new(1)
-    expect(T::Coerce[T::Hash[String, T.untyped]].new.from({a: obj})).to eq({'a' => obj})
+    expect(TypeCoerce[T::Hash[String, T.untyped]].new.from({a: obj})).to eq({'a' => obj})
   end
 end

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -2,7 +2,7 @@
 require 'sorbet-coerce'
 require 'sorbet-runtime'
 
-describe T::Coerce do
+describe TypeCoerce do
   context 'when given nested types' do
     class User < T::Struct
       const :id, Integer
@@ -15,7 +15,7 @@ describe T::Coerce do
     end
 
     it 'works with nest T::Struct' do
-      converted = T::Coerce[NestedParam].new.from({
+      converted = TypeCoerce[NestedParam].new.from({
         users: [{id: '1'}],
         params: {
           users: [{id: '2', valid: 'true'}],
@@ -42,16 +42,16 @@ describe T::Coerce do
 
     it 'works with nest T::Array' do
       expect {
-        T::Coerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
-      }.to raise_error(T::Coerce::CoercionError)
+        TypeCoerce[T::Array[T.nilable(Integer)]].new.from(['1', 'invalid', '3'])
+      }.to raise_error(TypeCoerce::CoercionError)
       expect(
-        T::Coerce[T::Array[T::Array[Integer]]].new.from([nil])
+        TypeCoerce[T::Array[T::Array[Integer]]].new.from([nil])
       ).to eql([[]])
       expect(
-        T::Coerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
+        TypeCoerce[T::Array[T::Array[Integer]]].new.from([['1'], ['2'], ['3']]),
       ).to eql [[1], [2], [3]]
 
-      expect(T::Coerce[
+      expect(TypeCoerce[
         T::Array[
           T::Array[
             T::Array[User]
@@ -59,7 +59,7 @@ describe T::Coerce do
         ]
       ].new.from([[[{id: '1'}]]]).flatten.first.id).to eql(1)
 
-      expect(T::Coerce[
+      expect(TypeCoerce[
         T::Array[
           T::Array[
             T::Array[
@@ -71,7 +71,7 @@ describe T::Coerce do
         ]
       ].new.from([[[[[{id: 1}]]]]]).flatten.first.id).to eql 1
 
-      expect(T::Coerce[
+      expect(TypeCoerce[
         T.nilable(T::Array[T.nilable(T::Array[T.nilable(User)])])
       ].new.from([[{id: '1'}]]).flatten.map(&:id)).to eql([1])
     end

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -2,12 +2,12 @@
 require 'sorbet-coerce'
 require 'sorbet-runtime'
 
-describe T::Coerce do
+describe TypeCoerce do
   context 'when type errors are soft errors' do
     let(:ignore_error) { Proc.new {} }
 
     before(:each) do
-      allow(T::Coerce::Configuration).to receive(
+      allow(TypeCoerce::Configuration).to receive(
         :raise_coercion_error,
       ).and_return(false)
 
@@ -42,24 +42,24 @@ describe T::Coerce do
 
     it 'overwrites the global config when inline config is set' do
       expect {
-        T::Coerce[Integer].new.from(invalid_arg, raise_coercion_error: true)
-      }.to raise_error(T::Coerce::CoercionError)
+        TypeCoerce[Integer].new.from(invalid_arg, raise_coercion_error: true)
+      }.to raise_error(TypeCoerce::CoercionError)
     end
 
     it 'works as expected' do
-      expect(T::Coerce[Integer].new.from(invalid_arg)).to eql(nil)
+      expect(TypeCoerce[Integer].new.from(invalid_arg)).to eql(nil)
 
-      expect{T::Coerce[T::Array[Integer]].new.from(1)}.to raise_error(T::Coerce::ShapeError)
-      expect(T::Coerce[T::Array[Integer]].new.from({a: 1})).to eql([nil])
+      expect{TypeCoerce[T::Array[Integer]].new.from(1)}.to raise_error(TypeCoerce::ShapeError)
+      expect(TypeCoerce[T::Array[Integer]].new.from({a: 1})).to eql([nil])
 
       expect {
-        T::Coerce[CustomTypeRaisesHardError].new.from(1)
+        TypeCoerce[CustomTypeRaisesHardError].new.from(1)
       }.to raise_error(StandardError)
-      expect(T::Coerce[CustomTypeDoesNotRiaseHardError].new.from(1)).to eql(1)
+      expect(TypeCoerce[CustomTypeDoesNotRiaseHardError].new.from(1)).to eql(1)
 
       sorbet_version = Gem.loaded_specs['sorbet-runtime'].version
       if sorbet_version >= Gem::Version.new('0.4.4948')
-        expect(T::Coerce[ParamsWithSortError].new.from({a: invalid_arg}).a).to eql(nil)
+        expect(TypeCoerce[ParamsWithSortError].new.from({a: invalid_arg}).a).to eql(nil)
       end
     end
   end

--- a/spec/sorbet_test_cases.rb
+++ b/spec/sorbet_test_cases.rb
@@ -1,22 +1,22 @@
 # typed: true
 require 'sorbet-coerce'
 
-T.assert_type!(T::Coerce[Integer].new.from('1'), Integer)
+T.assert_type!(TypeCoerce[Integer].new.from('1'), Integer)
 T.assert_type!(
-  T::Coerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
+  TypeCoerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
   T.nilable(Integer),
 )
 
-T::Coerce::Configuration.raise_coercion_error = true
+TypeCoerce::Configuration.raise_coercion_error = true
 coercion_error = nil
 begin
-  T::Coerce[T.nilable(Integer)].new.from('invalid')
-rescue T::Coerce::CoercionError => e
+  TypeCoerce[T.nilable(Integer)].new.from('invalid')
+rescue TypeCoerce::CoercionError => e
   coercion_error = e
 end
 raise 'no coercion error is raised' unless coercion_error
 
 T.assert_type!(
-  T::Coerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
+  TypeCoerce[T.nilable(Integer)].new.from('invalid', raise_coercion_error: false),
   T.nilable(Integer),
 )


### PR DESCRIPTION
This replaces all `T::Coerce﻿` with `TypeCoerce`. Grep for "T::Coerce" and see no results.
