### PR TITLE
Return the original tstruct/simple-type instance when type matches

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -75,9 +75,13 @@ module TypeCoerce::Private
             type.is_a?(T::Private::Types::TypeAlias)
         _convert(value, type.aliased_type, raise_coercion_error)
       elsif type.respond_to?(:<) && type < T::Struct
+        return value if value.is_a?(type)
+
         args = _build_args(value, type, raise_coercion_error)
         type.new(args)
       else
+        return value if value.is_a?(type)
+
         _convert_simple(value, type, raise_coercion_error)
       end
     end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -99,6 +99,7 @@ describe TypeCoerce do
       expect(param.info.name).to eql 'mango'
       expect(param.info.skill_ids).to eql [123, 456]
       expect(param.opt.notes).to eql []
+      expect(TypeCoerce[Param].new.from(param)).to eq(param)
 
       expect(param2.id).to eql 2
       expect(param2.info.name).to eql 'honeydew'
@@ -163,8 +164,10 @@ describe TypeCoerce do
 
   context 'when given custom types' do
     it 'coerces correctly' do
-      T.assert_type!(TypeCoerce[CustomType].new.from(a: 1), CustomType)
-      expect(TypeCoerce[CustomType].new.from(1).a).to be 1
+      obj = TypeCoerce[CustomType].new.from(1)
+      T.assert_type!(obj, CustomType)
+      expect(obj.a).to be 1
+      expect(TypeCoerce[CustomType].new.from(obj)).to be obj
 
       expect{TypeCoerce[UnsupportedCustomType].new.from(1)}.to raise_error(ArgumentError)
       # CustomType2.new(anything) returns Integer 1; 1.is_a?(CustomType2) == false


### PR DESCRIPTION
Summary
-------
Flagged by https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1587717186192700?thread_ts=1587706581.190900&cid=CHN2L03NH

```ruby

class A < T::Struct
  const :i, Integer
end

TypeCoerce[A].new.from(A.new(i: 1)) # Runtime error here
```

Test Plan
---------
Included test cases to cover this behavior.