### PR TITLE
Add Sorbet enum coercion

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -118,6 +118,8 @@ class TypeCoerce::Converter
       return value
     elsif PRIMITIVE_TYPES.include?(type)
       safe_type_rule = SafeType.const_get(type.name).strict
+    elsif type < T::Enum
+      return type.deserialize(value)
     else
       safe_type_rule = type
     end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -35,6 +35,17 @@ describe TypeCoerce do
       const :myhash, T::Hash[String, Integer], default: Hash['a' => 1]
     end
 
+    class TestEnum < T::Enum
+      enums do
+        Test = new
+        Other = new
+      end
+    end
+
+    class WithEnum < T::Struct
+      const :myenum, TestEnum
+    end
+
     class CustomType
       attr_reader :a
 
@@ -251,6 +262,18 @@ describe TypeCoerce do
 
     it 'coerces correctly' do
       expect(TypeCoerce[MyType].new.from('false')).to be false
+    end
+  end
+
+  context 'when dealing with enums' do
+    it 'coerces a serialized enum correctly' do
+      coerced = TypeCoerce[WithEnum].new.from(myenum: "test")
+      expect(coerced.myenum).to eq(TestEnum::Test)
+    end
+
+    it 'handles a real enum correctly' do
+      coerced = TypeCoerce[WithEnum].new.from(myenum: TestEnum::Test)
+      expect(coerced.myenum).to eq(TestEnum::Test)
     end
   end
 


### PR DESCRIPTION
This allows the gem to coerce Sorbet enums from their serialized representations.