### PR TITLE
Control Enum conversion via raise_coercion_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ T.reveal_type(converted) # <Type>
 - Custom Types: If the values can be coerced by `.new`
 - `T.untyped` (an escape hatch to ignore & return the given value)
 - `T::Boolean`
+- `T::Enum`
 - `T.nilable(<supported type>)`
 - `T::Array[<supported type>]`
 - `T::Hash[<supported type>, <supported type>]`
@@ -41,7 +42,6 @@ T.reveal_type(converted) # <Type>
 - Subclasses of `T::Struct`
 
 We don't support
-- `T::Enum` (currently)
 - Experimental features (tuples and shapes)
 - `T.any(<supported type>, ...)`: A union type other than `T.nilable`
 

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -275,6 +275,12 @@ describe TypeCoerce do
       coerced = TypeCoerce[WithEnum].new.from(myenum: TestEnum::Test)
       expect(coerced.myenum).to eq(TestEnum::Test)
     end
+
+    it 'handles bad enum' do
+      expect {
+        TypeCoerce[WithEnum].new.from(myenum: "bad_key")
+      }.to raise_error(TypeCoerce::CoercionError)
+    end
   end
 
   it 'works with T.untyped' do

--- a/spec/soft_error_spec.rb
+++ b/spec/soft_error_spec.rb
@@ -4,6 +4,12 @@ require 'sorbet-runtime'
 
 describe TypeCoerce do
   context 'when type errors are soft errors' do
+    class SoftErrorTestEnum < T::Enum
+      enums do
+        Other = new
+      end
+    end
+
     let(:ignore_error) { Proc.new {} }
 
     before(:each) do
@@ -48,6 +54,7 @@ describe TypeCoerce do
 
     it 'works as expected' do
       expect(TypeCoerce[Integer].new.from(invalid_arg)).to eql(nil)
+      expect(TypeCoerce[SoftErrorTestEnum].new.from('bad_key')).to eql(nil)
 
       expect{TypeCoerce[T::Array[Integer]].new.from(1)}.to raise_error(TypeCoerce::ShapeError)
       expect(TypeCoerce[T::Array[Integer]].new.from({a: 1})).to eql([nil])


### PR DESCRIPTION
### Summary
- allows the enum conversion to return nil if raise_coercion_error is set to `false`
- move `T::Enum` to supported types

### Test Plan
- added test cases to cover this behavior