### PR TITLE
Enable conversion of Float's to BigNum's

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -131,7 +131,7 @@ class TypeCoerce::Converter
     elsif value.is_a?(type)
       return value
     elsif type == BigDecimal
-      return BigDecimal(value)
+      return BigDecimal(value, 0)
     elsif PRIMITIVE_TYPES.include?(type)
       safe_type_rule = SafeType.const_get(type.name).strict
     else

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -159,6 +159,7 @@ describe TypeCoerce do
       T.assert_type!(TypeCoerce[Integer].new.from(1), Integer)
       T.assert_type!(TypeCoerce[Integer].new.from('1.0'), Integer)
       T.assert_type!(TypeCoerce[T.nilable(Integer)].new.from(nil), T.nilable(Integer))
+      T.assert_type!(TypeCoerce[BigDecimal].new.from('1.0'), BigDecimal)
     end
 
     it 'coreces correctly' do
@@ -176,6 +177,8 @@ describe TypeCoerce do
       expect(TypeCoerce[T.nilable(Integer)].new.from('')).to be nil
       expect{TypeCoerce[T.nilable(Integer)].new.from([])}.to raise_error(TypeCoerce::CoercionError)
       expect(TypeCoerce[T.nilable(String)].new.from('')).to eql ''
+
+      expect(TypeCoerce[BigDecimal].new.from(123.321)).to eql BigDecimal(123.321, 0)
     end
   end
 


### PR DESCRIPTION
When converting from a Float, the following error is given:

Exception: can't omit precision for a Float.

This PR fixes that.