### PR TITLE
Keep unsupported union values as-is

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -65,9 +65,7 @@ class TypeCoerce::Converter
         false_idx = i if t.is_a?(T::Types::Simple) && t.raw_type == FalseClass
       end
 
-      raise ArgumentError.new(
-        'the only supported union types are T.nilable and T::Boolean',
-      ) unless (
+      return value unless (
         (!true_idx.nil? && !false_idx.nil? && !nil_idx.nil?) || # T.nilable(T::Boolean)
         (type.types.length == 2 && (
           !nil_idx.nil? || (!true_idx.nil? && !false_idx.nil?) # T.nilable || T::Boolean


### PR DESCRIPTION
## Summary
* Keep unsupported union values as-is, instead of raising error. Let sorbet itself raise error if the value does not fit into the union type.
 
## Description
I believe this behavior makes it more convenient to deal with union types when coercing.