### PR TITLE
Allow coercing for T::InexactStruct

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -93,7 +93,7 @@ class TypeCoerce::Converter
     elsif Object.const_defined?('T::Private::Types::TypeAlias') &&
           type.is_a?(T::Private::Types::TypeAlias)
       _convert(value, type.aliased_type, raise_coercion_error)
-    elsif type.respond_to?(:<) && type < T::Struct
+    elsif type.respond_to?(:<) && type < T::InexactStruct
       return value if value.is_a?(type)
 
       args = _build_args(value, type, raise_coercion_error)


### PR DESCRIPTION
This PR allows coercing for `T::InexactStruct` from hashes

Specifically want to support this kind of scenario

```ruby
class PaginatedResponse < T::InexactStruct
  const :count,    Integer
  const :next,     T.nilable(String)
  const :previous, T.nilable(String)
  const :results,  T::Array[T.untyped]
end

class Location < T::Struct
  const :id,   String
  const :name, String
end

class Sale < T::Struct
  const :time,   Time
  const :amount, Float
end

class PaginatedLocationsResponse < PaginatedResponse
  const :results, T::Array[Location], override: true
end

class PaginatedSalesResponse < PaginatedResponse
  const :results, T::Array[Sale], override: true
end


locations_response = TypeCoerce[PaginatedLocationsResponse].new.from({
  "count" => 1,
  "next" => nil,
  "previous" => nil,
  "results" => [
	{
      "id" => "3434",
      "name" => "Liverpool Street"
    }
  ]
})

sales_response = TypeCoerce[PaginatedSalesResponse].new.from({
  "count" => 1,
  "next" => nil,
  "previous" => nil,
  "results" => [
	{
      "time" => "2021-06-15 08:37:30 +0000"
      "amount" => "6.95"
    }
  ]
})
```