### PR TITLE
Handle T.class_of and unknown types

### DIFF
--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -95,19 +95,23 @@ class TypeCoerce::Converter
     elsif Object.const_defined?('T::Private::Types::TypeAlias') &&
           type.is_a?(T::Private::Types::TypeAlias)
       _convert(value, type.aliased_type, raise_coercion_error)
-    elsif type.respond_to?(:<) && type < T::Struct
+    elsif type.is_a?(Class) || type.is_a?(Module)
       return value if value.is_a?(type)
 
-      args = _build_args(value, type, raise_coercion_error)
-      type.new(args)
-    elsif type.respond_to?(:<) && type < T::Enum
-      return value if value.is_a?(type)
-
-      _convert_enum(value, type, raise_coercion_error)
+      if type < T::Struct
+        args = _build_args(value, type, raise_coercion_error)
+        type.new(args)
+      elsif type < T::Enum
+        _convert_enum(value, type, raise_coercion_error)
+      else
+        _convert_simple(value, type, raise_coercion_error)
+      end
     else
-      return value if value.is_a?(type)
-
-      _convert_simple(value, type, raise_coercion_error)
+      if raise_coercion_error
+        raise TypeCoerce::CoercionError.new(value, type)
+      else
+        value
+      end
     end
   end
 

--- a/lib/sorbet-coerce/converter.rb
+++ b/lib/sorbet-coerce/converter.rb
@@ -48,6 +48,8 @@ class TypeCoerce::Converter
   def _convert(value, type, raise_coercion_error)
     if type.is_a?(T::Types::Untyped)
       value
+    elsif type.is_a?(T::Types::ClassOf)
+      value
     elsif type.is_a?(T::Types::TypedArray)
       _convert_to_a(value, type.type, raise_coercion_error)
     elsif type.is_a?(T::Types::TypedSet)

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -348,4 +348,21 @@ describe TypeCoerce do
       end.to raise_error(TypeError)
     end
   end
+
+  context 'when dealing with unknown types' do
+    context 'raise_coercion_error is enabled' do
+      it 'raises error' do
+        expect do
+          TypeCoerce['a'].new.from('a', raise_coercion_error: true)
+        end.to raise_error(TypeCoerce::CoercionError)
+      end
+    end
+    context 'raise_coercion_error is disabled' do
+      it 'keeps the value as-is (and let Sorbet raise error)' do
+        expect do
+          TypeCoerce['a'].new.from('a', raise_coercion_error: false)
+        end.to raise_error(/must be an T::Types::Base/i)
+      end
+    end
+  end
 end

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -72,6 +72,9 @@ describe TypeCoerce do
       const :union, T.any(String, Integer)
     end
 
+    class CustomString < String
+    end
+
     let!(:param) {
       TypeCoerce[Param].new.from({
         id: 1,
@@ -330,5 +333,19 @@ describe TypeCoerce do
 
     obj = CustomType.new(1)
     expect(TypeCoerce[T::Hash[String, T.untyped]].new.from({a: obj})).to eq({'a' => obj})
+  end
+
+  context 'when dealing with T.class_of' do
+    it 'keeps the value as-is' do
+      string_class_type = T.class_of(String)
+      expect(TypeCoerce[string_class_type].new.from(String)).to eql(String)
+      expect(TypeCoerce[string_class_type].new.from(CustomString)).to eql(CustomString)
+      expect do
+        TypeCoerce[string_class_type].new.from(Integer)
+      end.to raise_error(TypeError)
+      expect do
+        TypeCoerce[string_class_type].new.from('a')
+      end.to raise_error(TypeError)
+    end
   end
 end


### PR DESCRIPTION
## Summary
Currently, using `TypeCoerce` on `T.class_of` raises an uncaught exception:  
![image](https://user-images.githubusercontent.com/15865062/134292481-2dd3c05a-3969-4aa2-b7a1-768e9a4d02e2.png)  
(see example in the new spec)

This PR tries to:
* Keep values as-is when dealing with `T.class_of` types
* Improve the handling of unknown types
