### PR TITLE
Removes duplicate `Enumerable` definition

### DIFF
--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -2953,10 +2953,6 @@ class Encoding
   def self._load(arg); end
 end
 
-module Enumerable
-  def sum(*arg); end
-end
-
 class Enumerator
   def +(arg); end
 


### PR DESCRIPTION
Basically a followup to #74 - introduced here: https://github.com/sorbet/sorbet/commit/cc2dc78db81f31011566c9986695a11a3f3dc1e4